### PR TITLE
chore(deps): raise transformers/gradio to security floors (closes 22 of 28 Dependabot alerts)

### DIFF
--- a/app.py
+++ b/app.py
@@ -176,7 +176,7 @@ class App:
                     with gr.TabItem(_("Mic")):  # tab3
                         with gr.Row():
                             mic_input = gr.Microphone(label=_("Record with Mic"), type="filepath", interactive=True,
-                                                      show_download_button=True)
+                                                      buttons=["download"])
 
                         pipeline_params, dd_file_format, cb_timestamp = self.create_pipeline_inputs()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,9 @@ torch>=2.8.0,<2.9.0 # Needs to be harmonized with torchaudio
 torchaudio>=2.8.0,<2.9.0 # 2.9 deprecates used functions
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.1.1
-transformers==4.47.1
-gradio==5.29.0
-gradio-i18n==0.3.1
+transformers>=5.5.0,<6.0.0 # Security floor: GHSA-fgcw-684q-jj6r (RCE at model init)
+gradio>=6.15.1,<7.0.0 # Security floor: GHSA-6655-8ph2-63j3, GHSA-7hp7-4p35-3cx2
+gradio-i18n>=0.3.2,<0.4.0 # 0.3.1 raises LookupError on gradio 6 at import time
 pytubefix
 ruamel.yaml==0.18.6
 pyannote.audio==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,10 @@ torch>=2.8.0,<2.9.0 # Needs to be harmonized with torchaudio
 torchaudio>=2.8.0,<2.9.0 # 2.9 deprecates used functions
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.1.1
-transformers>=5.5.0,<6.0.0 # Security floor: GHSA-fgcw-684q-jj6r (RCE at model init)
+# Held below 5.0: transformers 5 removed the "translation" pipeline task, which
+# modules/translation/nllb_inference.py depends on. Leaves GHSA-69w3-r845-3855,
+# GHSA-29pf-2h5f-8g72 and GHSA-fgcw-684q-jj6r open pending an NLLB rewrite.
+transformers>=4.53.0,<5.0.0 # Security floor: GHSA-4w7r-h757-3r74 and 13 other advisories
 gradio>=6.15.1,<7.0.0 # Security floor: GHSA-6655-8ph2-63j3, GHSA-7hp7-4p35-3cx2
 gradio-i18n>=0.3.2,<0.4.0 # 0.3.1 raises LookupError on gradio 6 at import time
 pytubefix


### PR DESCRIPTION
## What this does

Closes **22 of the 28 open Dependabot alerts** by replacing two exact pins with bounded security
floors, plus the two code changes those floors require.

| package | before | after | alerts cleared |
|---|---|---|---|
| `transformers` | `==4.47.1` | `>=4.53.0,<5.0.0` | **14** (#4 #5 #6 #7 #8 #10 #11 #12 #13 #14 #15 #16 #17 #18) |
| `gradio` | `==5.29.0` | `>=6.15.1,<7.0.0` | **8** (#19 #20 #21 #22 #23 #24 #29 #32) |
| `gradio-i18n` | `==0.3.1` | `>=0.3.2,<0.4.0` | 0 (required companion — see below) |
| `transformers` 5.x-only | — | *not taken* | 0 — **3 left open** (#25 #30 #31), blocker below |
| `torch` | `>=2.8.0,<2.9.0` | *unchanged* | 0 — **3 left open** (#26 #27 #33), blocker below |

The 28 alerts collapse to just **3 packages**: `transformers` ×17, `gradio` ×8, `torch` ×3.

Floors are **bounded** (`>=floor,<next-major`) rather than exact pins, so Dependabot can keep
proposing in-range patch updates instead of treating the dependency as frozen.

### Verified against each advisory's own range

Checked by intersecting each proposed specifier with each advisory's own
`vulnerable_version_range` over the real PyPI version list — not against `first_patched_version`
alone:

```
SUMMARY: 22/28 alerts resolved by proposed ranges; 6 remain
remaining by package: {'transformers': [25, 30, 31], 'torch': [26, 27, 33]}
SELF-TEST (transformers floor lowered to 4.0.0 vs alert #4): FIRED - detector works
```

Worth calling out: **alert #20 (GHSA-wmjh-cpqj-4v6x) reports no `first_patched_version` at all**, so
it looks unfixable. But its range is `>= 5.0.0, <= 5.29.1` — bounded *above* — so any 6.x is outside
it. Reading the range rather than the patch field is what resolves it.

## Why transformers stops at 4.x (3 alerts deliberately left open)

This PR originally proposed `transformers>=5.5.0,<6.0.0` for 25/28. Once #11 unblocked dependency
installation, the suite ran for real and **failed**:

```
KeyError: "Unknown task translation, available tasks are ['any-to-any', 'audio-classification', ...]"
  transformers/pipelines/base.py:1358
  modules/translation/nllb_inference.py:62  ->  pipeline("translation", ...)

test (3.10)  transformers 5.14.1:  collected 20 items -> 2 failed, 7 passed, 11 skipped
master       transformers 4.47.1:  collected 20 items ->           9 passed, 11 skipped
```

transformers 5 exposes **27 pipeline tasks and none is translation-capable** — no `translation`, no
`translation_XX_to_YY`, no `text2text-generation`, no `summarization`. The entire seq2seq pipeline
family was removed, so **there is no task string to swap to**. Restoring NLLB translation on v5 means
driving the model directly through `generate()` with `forced_bos_token_id` instead of the pipeline
API — a feature rewrite, not a dependency bump.

So the floor is `>=4.53.0,<5.0.0`: the highest reachable inside 4.x, clearing 14 of 17. The three
that need 5.x (#25 GHSA-69w3-r845-3855, #30 GHSA-29pf-2h5f-8g72, #31 GHSA-fgcw-684q-jj6r — the last
two are **high**) stay open and are named inline in `requirements.txt` so they are not silently
forgotten.

Note this was invisible to static analysis: `pipeline` still exists as a symbol in v5 and imports
fine. Only executing the test revealed the task registry no longer accepts `"translation"`.

## Code changes the gradio 5 → 6 bump requires

**1. `app.py` — `gr.Microphone`.** gradio 6 replaced `show_download_button` / `show_share_button` on
audio components with a unified `buttons: list[Literal['download','share']] | None`.

**2. `gradio-i18n` 0.3.1 is incompatible with gradio 6.** `gettext()` raises at *module import* time,
breaking `modules/utils/constants.py:3` and therefore the whole app:

```
gradio 5.29.0 + gradio-i18n 0.3.1 -> constants import: OK
gradio 6.20.0 + gradio-i18n 0.3.1 -> constants import: FAIL -> LookupError <ContextVar name='request'>
gradio 6.17.3 + gradio-i18n 0.3.4 -> constants import: OK
```

## Resolution note

transformers 4.x caps `huggingface-hub<1.0` while gradio 6.20.0 wants `hub>=1.2.0`, so pip backtracks
gradio. The resolved set is **transformers 4.57.6 + gradio 6.17.3 + gradio-i18n 0.3.4 +
huggingface_hub 0.36.2**, which still satisfies every gradio floor (max required is 6.15.1).

Verified against that exact resolved set:

- `translation` pipeline task **present** (34 tasks)
- `gr.Microphone` accepts `buttons=`, no longer accepts `show_download_button`
- `gradio.utils.NamedString` and `gradio.components.base.FormComponent` both import
- `transformers.utils.is_flash_attn_2_available` imports
- all **178** `gr.*` call sites pass the signature check — **0 problems**, with the checker
  self-tested to fire on an injected bogus kwarg

## Why `torch` is not bumped (3 alerts left open: #26, #27, #33)

Not a version bump — a code migration:

- `torchaudio` pins `torch` **exactly** (`torchaudio 2.8.0 -> torch==2.8.0`), so the pair moves
  together or not at all.
- `torchaudio.info` is **removed** from 2.9 onward, and the repo calls it at
  `modules/uvr/music_separator.py:108`. Measured from each wheel's `__all__`:
  `2.8.0 -> ['AudioMetaData','info','list_audio_backends','load','save']` vs
  `2.9.1 / 2.10.0 / 2.11.0 -> ['load','save']`. Calling it on 2.9.1 raises
  `AttributeError: module 'torchaudio' has no attribute 'info'`.
- `torchaudio.load` (used at `modules/whisper/base_transcription_pipeline.py:615`) still exists but
  from 2.9 routes through **`torchcodec`**, which is not a dependency here.
- Alert #33 needs `torch >= 2.13.0`, and **no matching `torchaudio` exists at all** (latest is
  2.11.0).
