### PR TITLE
fix(ci): constrain setuptools<82 so the whisper source dependency can build (unblocks all CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
       - master
       - intel-gpu
 
+# Constrain pip's isolated build environment for every job below. Required because
+# one source dependency's setup.py imports pkg_resources, which setuptools 82
+# removed. See constraints.txt for the full explanation.
+env:
+  PIP_CONSTRAINT: ${{ github.workspace }}/constraints.txt
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ RUN apt-get update && \
 
 WORKDIR /Whisper-WebUI
 
-COPY requirements.txt .
+COPY requirements.txt constraints.txt ./
+
+# PIP_CONSTRAINT constrains pip's isolated build environment. Required because one
+# source dependency's setup.py imports pkg_resources, which setuptools 82 removed.
+# See constraints.txt for the full explanation.
+ENV PIP_CONSTRAINT=/Whisper-WebUI/constraints.txt
 
 RUN python3 -m venv venv && \
     . venv/bin/activate && \

--- a/Install.bat
+++ b/Install.bat
@@ -8,6 +8,11 @@ echo checked the venv folder. now installing requirements..
 
 call "%~dp0\venv\scripts\activate"
 
+REM Constrain pip's isolated build environment. Required because one source
+REM dependency's setup.py imports pkg_resources, which setuptools 82 removed.
+REM See constraints.txt for the full explanation.
+set "PIP_CONSTRAINT=%~dp0constraints.txt"
+
 python -m pip install -U pip
 pip install -r requirements.txt
 

--- a/Install.sh
+++ b/Install.sh
@@ -7,6 +7,11 @@ fi
 
 source venv/bin/activate
 
+# Constrain pip's isolated build environment. Required because one source
+# dependency's setup.py imports pkg_resources, which setuptools 82 removed.
+# See constraints.txt for the full explanation.
+export PIP_CONSTRAINT="$(cd "$(dirname "$0")" && pwd)/constraints.txt"
+
 python -m pip install -U pip
 pip install -r requirements.txt && echo "Requirements installed successfully." || {
     echo ""

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,26 @@
+# Build-time pip constraint, applied via the PIP_CONSTRAINT environment variable.
+#
+# Why this file exists
+# --------------------
+# requirements.txt installs `git+https://github.com/jhj0517/jhj0517-whisper.git`,
+# a source dependency whose setup.py does `import pkg_resources` on line 5.
+#
+# setuptools removed the bundled `pkg_resources` package in 82.0.0 (it is still
+# shipped in 81.0.0 and earlier). That repository declares no [build-system] table,
+# so pip installs the newest setuptools into its isolated build environment and the
+# setup.py can no longer run:
+#
+#     ModuleNotFoundError: No module named 'pkg_resources'
+#     ERROR: Failed to build 'git+https://github.com/jhj0517/jhj0517-whisper.git'
+#           when getting requirements to build wheel
+#
+# That breaks every `pip install -r requirements.txt`, which is why CI cannot get
+# past dependency installation.
+#
+# Note: a `-c constraints.txt` line inside requirements.txt does NOT fix this - pip
+# does not propagate requirements-file constraints into the isolated build
+# environment. The PIP_CONSTRAINT environment variable does, so Install.sh,
+# Install.bat, the Dockerfile and the CI workflow each set it.
+#
+# Remove this constraint once the upstream package stops importing pkg_resources.
+setuptools<82


### PR DESCRIPTION
## Problem

Every `pip install -r requirements.txt` in this repo fails right now. All 9 CI jobs fail on
`master`, so no pull request can be verified — the gate is red for reasons unrelated to whatever
a PR changes.

`requirements.txt` line 15 installs `git+https://github.com/jhj0517/jhj0517-whisper.git`, whose
`setup.py` does `import pkg_resources` on line 5. setuptools removed the bundled `pkg_resources`
package in **82.0.0**, and that repository declares no `[build-system]` table, so pip installs the
newest setuptools into its isolated build environment and the `setup.py` can no longer execute:

```
Getting requirements to build wheel: finished with status 'error'
  File "<string>", line 5, in <module>
ModuleNotFoundError: No module named 'pkg_resources'
ERROR: Failed to build 'git+https://github.com/jhj0517/jhj0517-whisper.git' when getting requirements to build wheel
```

pip aborts at line 15, **before any other dependency is resolved** — a CI log for a dependency PR
shows `Collecting transformers|gradio` matching **0** times.

Measured from the setuptools wheels themselves, so the bound is the least restrictive one that works:

```
setuptools 80.9.0    ships pkg_resources/: True
setuptools 80.10.2   ships pkg_resources/: True
setuptools 81.0.0    ships pkg_resources/: True
setuptools 82.0.0    ships pkg_resources/: False
setuptools 83.0.0    ships pkg_resources/: False
```

## Fix

Add `constraints.txt` containing `setuptools<82`, and point `PIP_CONSTRAINT` at it from all four
places this project installs dependencies:

| where | change |
|---|---|
| `.github/workflows/ci.yml` | one workflow-level `env:` — covers all three jobs |
| `Install.sh` | `export PIP_CONSTRAINT=...` (the documented local path, README step 2) |
| `Install.bat` | `set "PIP_CONSTRAINT=..."` (the documented local path, README step 2) |
| `Dockerfile` | `COPY` the file + `ENV PIP_CONSTRAINT=...` |

**No project dependency changes** — the resolved dependency set is untouched. This only bounds the
setuptools that pip puts in its throwaway build environment.

## Why `PIP_CONSTRAINT`, and not something smaller

Each alternative was tested and rejected on evidence, not on preference:

- **`-c constraints.txt` inside `requirements.txt`** — does **not** work. pip does not propagate
  requirements-file constraints into the isolated build environment; the install fails identically
  to using no constraint at all. This was the smallest candidate and it was measured, not assumed.
- **`--no-build-isolation` in `requirements.txt`** — not a valid requirements-file option; pip exits
  with a usage error.
- **Pinning `setuptools` in `requirements.txt`** — no effect, because build isolation uses a
  separate overlay environment.
- **Replacing the git dependency with a published wheel** — no wheel exists. PyPI ships
  `openai-whisper` as an **sdist only** for every release (`20230117` … `20250625`), so it would
  rebuild from the same `setup.py` and hit the same failure.

Vendoring or forking the upstream package was deliberately avoided.

## Verification

**Both states, using this repo's own `constraints.txt`, on the actual git dependency:**

```
STATE A: WITHOUT the fix (no PIP_CONSTRAINT)
  ModuleNotFoundError: No module named 'pkg_resources'
  ERROR: Failed to build
  -> import whisper: ModuleNotFoundError: No module named 'whisper'

STATE B: WITH the fix (PIP_CONSTRAINT = repo constraints.txt)
  Successfully installed openai-whisper-20240930
  -> pip show openai-whisper: Name: openai-whisper / Version: 20240930
```

Also checked:

- `ci.yml` parses, and the workflow-level `env` is visible to all three jobs
  (`test`, `test-backend`, `test-shell-script`).
- The committed `Install.sh` blob passes `bash -n` under **real Linux bash** (exit 0), with a
  deliberately-broken control script confirming the check actually fires (exit 2). All committed
  blobs are LF.
- `Install.sh` resolves `constraints.txt` correctly when invoked from an unrelated working
  directory.

### Honest limits

Local verification bounded the install to the one dependency that was failing (`--no-deps`), because
a full `pip install -r requirements.txt` pulls the CUDA torch wheels and did not fit in local disk.
**CI on this PR is the full end-to-end proof** — if these jobs get past dependency installation, the
fix works for the complete requirement set. Note that `constraints.txt` applies to every pip call in
the affected contexts, not only builds; since it contains one entry and setuptools is not a runtime
dependency here, the practical effect is confined to the build environment.

Remove the constraint once upstream stops importing `pkg_resources`.
